### PR TITLE
Remove duplicate partitions

### DIFF
--- a/src/refind_btrfs/device/partition_table.py
+++ b/src/refind_btrfs/device/partition_table.py
@@ -70,7 +70,7 @@ class PartitionTable:
         return self
 
     def with_partitions(self, partitions: Iterable[Partition]) -> Self:
-        self._partitions = list(partitions)
+        self._partitions = list(set(partitions))
 
         return self
 

--- a/src/refind_btrfs/device/partition_table.py
+++ b/src/refind_btrfs/device/partition_table.py
@@ -70,7 +70,7 @@ class PartitionTable:
         return self
 
     def with_partitions(self, partitions: Iterable[Partition]) -> Self:
-        self._partitions = list(set(partitions))
+        self._partitions = list(partitions)
 
         return self
 

--- a/src/refind_btrfs/system/findmnt_command.py
+++ b/src/refind_btrfs/system/findmnt_command.py
@@ -82,7 +82,7 @@ class FindmntCommand(DeviceCommand):
         output = constants.COLUMN_SEPARATOR.join(
             [findmnt_column_key.value.upper() for findmnt_column_key in findmnt_columns]
         )
-        findmnt_command = f"findmnt --json --mtab --real --nofsroot --output {output}"
+        findmnt_command = f"findmnt --json --mtab --real --nofsroot --uniq --output {output}"
 
         try:
             logger.info(


### PR DESCRIPTION
* partitions are parsed from `/etc/fstab`

https://github.com/Venom1991/refind-btrfs/blob/8e0021a62d3d9446b8dcfdcdf0f97567dfdec232/src/refind_btrfs/system/fstab_command.py#L104

* it is parsed line by line

https://github.com/Venom1991/refind-btrfs/blob/8e0021a62d3d9446b8dcfdcdf0f97567dfdec232/src/refind_btrfs/system/fstab_command.py#L116

`fstab` files can reference partitions multiple times

<details>
<summary>Expand to see fstab example</summary>

```/etc/fstab
# Static information about the filesystems.
# See fstab(5) for details.

# <file system> <dir> <type> <options> <dump> <pass>
# /dev/sda2
UUID=e236ff63-85af-4097-a525-f37b7d182e2b	/         	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=256,subvol=/@	0 0

# /dev/sda1
UUID=5D01-B29B      	/boot     	vfat      	rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,utf8,errors=remount-ro	0 2

# /dev/sda2
# UUID=e236ff63-85af-4097-a525-f37b7d182e2b	/.snapshots	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=260,subvol=/@.snapshots	0 0

# /dev/sda2
UUID=e236ff63-85af-4097-a525-f37b7d182e2b	/home     	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=257,subvol=/@home	0 0

# /dev/sda2
UUID=e236ff63-85af-4097-a525-f37b7d182e2b	/home/username/Projects     	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=263,subvol=/@projects	0 0

# /dev/sdb2
UUID=01bfee92-10b9-42fd-88ba-a018abbe0086	/var/cache/pacman/pkg	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=260,subvol=/@pkg	0 0

# /dev/sda2
UUID=e236ff63-85af-4097-a525-f37b7d182e2b	/var/log  	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=258,subvol=/@log	0 0

# /dev/sdb2
UUID=01bfee92-10b9-42fd-88ba-a018abbe0086	/home/username/.cache     	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=257,subvol=/@cache	0 0

# /dev/sdb2
UUID=01bfee92-10b9-42fd-88ba-a018abbe0086	/home/username/.conan/data     	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=256,subvol=/@conan	0 0
# /dev/sdb2
UUID=01bfee92-10b9-42fd-88ba-a018abbe0086	/home/username/.cargo/     	btrfs     	rw,relatime,ssd,compress=zstd,discard=async,space_cache=v2,subvolid=261,subvol=/@cargo	0 0


```
</details>

thus returning a Partition multiple times. 

* in many cases the code assumes that a partition is only one time in the iterable

https://github.com/Venom1991/refind-btrfs/blob/8e0021a62d3d9446b8dcfdcdf0f97567dfdec232/src/refind_btrfs/device/partition_table.py#L172
https://github.com/Venom1991/refind-btrfs/blob/8e0021a62d3d9446b8dcfdcdf0f97567dfdec232/src/refind_btrfs/device/partition_table.py#L183
https://github.com/Venom1991/refind-btrfs/blob/8e0021a62d3d9446b8dcfdcdf0f97567dfdec232/src/refind_btrfs/device/partition_table.py#L194

* with the example fstab, following error is thrown:

<details><summary>python backtrace</summary>

```
Nov 17 12:30:07 systemd[1]: Started Generate rEFInd manual boot stanzas from Btrfs snapshots.
Nov 17 13:01:44 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: The '/.snapshots/1931' snapshot has been created.
Nov 17 13:01:44 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the block devices using lsblk.
Nov 17 13:01:44 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/loop0' using lsblk.
Nov 17 13:01:44 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/loop0' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/loop1' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/loop1' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/loop2' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/loop2' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/loop3' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/loop3' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/loop4' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/loop4' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/loop5' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/loop5' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/loop6' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/loop6' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/loop7' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/loop7' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/sda' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/sda' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/sdb' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/sdb' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/sdc' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/sdc' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/sr0' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/sr0' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the physical partition table for device '/dev/zram0' using lsblk.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: Initializing the live partition table for device '/dev/zram0' using findmnt.
Nov 17 13:01:45 /usr/lib/python3.11/site-packages/refind_btrfs/__main__.py[139597]: ERROR (refind_btrfs.service.snapshot_observer/snapshot_observer.py/run): An unexpected error happened, exiting...
Traceback (most recent call last):
    File "/usr/lib/python3.11/site-packages/refind_btrfs/service/snapshot_observer.py", line 45, in run
    self.dispatch_events(self.event_queue)
    File "/usr/lib/python3.11/site-packages/watchdog/observers/api.py", line 381, in dispatch_events
    handler.dispatch(event)
    File "/usr/lib/python3.11/site-packages/watchdog/events.py", line 283, in dispatch
    {
    File "/usr/lib/python3.11/site-packages/refind_btrfs/service/snapshot_event_handler.py", line 92, in on_created
    machine.run()
    File "/usr/lib/python3.11/site-packages/refind_btrfs/state_management/refind_btrfs_machine.py", line 102, in run
    while model.next_state():
            ^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 402, in trigger
    return self.machine._process(func)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 1211, in _process
    return trigger()
            ^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 416, in _trigger
    self._process(event_data)
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 439, in _process
    if trans.execute(event_data):
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 277, in execute
    self._change_state(event_data)
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 287, in _change_state
    event_data.machine.get_state(self.dest).enter(event_data)
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 129, in enter
    event_data.machine.callbacks(self.on_enter, event_data)
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 1146, in callbacks
    self.callback(func, event_data)
    File "/usr/lib/python3.11/site-packages/transitions/core.py", line 1167, in callback
    func(*event_data.args, **event_data.kwargs)
    File "/usr/lib/python3.11/site-packages/refind_btrfs/state_management/model.py", line 158, in initialize_block_devices
    block_device_filter(BlockDevice.has_boot),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/refind_btrfs/state_management/model.py", line 149, in block_device_filter
    return only(
            ^^^^^
    File "/usr/lib/python3.11/site-packages/more_itertools/more.py", line 3273, in only
    first_value = next(it, default)
                    ^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/refind_btrfs/state_management/model.py", line 152, in <genexpr>
    if filter_func(block_device)
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/refind_btrfs/device/block_device.py", line 99, in has_boot
    return self.boot is not None
            ^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/refind_btrfs/device/block_device.py", line 159, in boot
    return none_throws(self.live_partition_table).boot
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/functools.py", line 1001, in __get__
    val = self.func(instance)
            ^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/site-packages/refind_btrfs/device/partition_table.py", line 194, in boot
    return only(
            ^^^^^
    File "/usr/lib/python3.11/site-packages/more_itertools/more.py", line 3284, in only
    raise too_long or ValueError(msg)
ValueError: Expected exactly one item in iterable, but got <refind_btrfs.device.partition.Partition object at 0x7f4dc83b48d0>, <refind_btrfs.device.partition.Partition object at 0x7f4dc83b4bd0>, and perhaps more.

```

</summary>

Removing the duplicated partition objects via `set` resolves the issue. 

