### PR TITLE
Fix boot file validation logic for Btrfs subvolumes

### DIFF
--- a/src/refind_btrfs/boot/boot_stanza.py
+++ b/src/refind_btrfs/boot/boot_stanza.py
@@ -29,6 +29,7 @@ from collections import defaultdict
 from functools import cached_property, singledispatchmethod
 from itertools import chain
 from typing import Any, DefaultDict, Iterable, Iterator, Optional, Self, Set
+from pathlib import Path
 
 from more_itertools import always_iterable, last
 
@@ -189,13 +190,14 @@ class BootStanza:
             boot_file_paths = always_iterable(all_boot_file_paths.get(source))
 
             for boot_file_path in boot_file_paths:
-                append_func = (
-                    matched_boot_files.append
-                    if logical_path in boot_file_path
-                    else unmatched_boot_files.append
-                )
+                # Construct the full, absolute path to the file inside the subvolume
+                full_path_to_check = subvolume.filesystem_path / Path(boot_file_path).relative_to('/')
 
-                append_func(boot_file_path)
+                # Check if the file actually exists at that location
+                if full_path_to_check.exists():
+                    matched_boot_files.append(boot_file_path)
+                else:
+                    unmatched_boot_files.append(boot_file_path)
 
         self._boot_files_check_result = BootFilesCheckResult(
             normalized_name, logical_path, matched_boot_files, unmatched_boot_files


### PR DESCRIPTION
Hi,

Today, I was attempting to switch from grub to rEFInd but I had some trouble with getting `refind-btrfs` to recognize my `menuentry` correctly. My system uses a standard Arch Btrfs layout where `/boot` is a directory inside the `@` subvolume.

I found that if I created a bootable `menuentry` with simple paths (e.g., `loader /boot/vmlinuz-linux-cachyos`), the entry booted perfectly, but `refind-btrfs` would fail validation. If I changed the paths to what the script expected (`loader /@/boot/vmlinuz-linux-cachyos`), the script would work, but the entry would no longer boot from rEFInd. After some digging in the codebase, I found the cause and developed a fix.

#### Problem

Currently, the script's validation logic uses a simple string check (`logical_path in boot_file_path`) to see if the loader and initrd files are part of the root subvolume. This creates a catch-22 for users with a standard Btrfs-on-root setup:

  * A stanza with simple paths that **works for booting** fails script validation.
  * A stanza with the full logical paths that **passes validation** fails to boot.

This issue seems to be the root cause of the problems described in \#50 and a few other issues.

#### Solution

This PR fixes the validation logic in `BootStanza.with_boot_files_check_result()` by replacing the string comparison with a proper filesystem path check.

The new logic constructs the full, absolute path to the kernel within the subvolume (`subvolume.filesystem_path / Path(boot_file_path).relative_to('/')`) and uses `Path.exists()` to verify the file. This change allows a single, simple, and **bootable** `menuentry` in `refind.conf` to serve as a valid template for the script, resolving the conflict.

#### Key Changes

  * Modified `with_boot_files_check_result` in `src/refind_btrfs/boot/boot_stanza.py` to use filesystem path resolution instead of string matching.
  * Added `from pathlib import Path` to support this change.

This change is fully backward compatible; stanzas using the full logical path will continue to validate correctly.

#### Before (Fails with bootable paths)

```python
# The old logic incorrectly checks if the subvolume name is in the path string.
append_func = (
    matched_boot_files.append
    if logical_path in boot_file_path
    else unmatched_boot_files.append
)
append_func(boot_file_path)
```

#### After (Works with bootable paths)

```python
# The new logic constructs the real path and checks if the file exists.
full_path_to_check = subvolume.filesystem_path / Path(boot_file_path).relative_to('/')

if full_path_to_check.exists():
    matched_boot_files.append(boot_file_path)
else:
    unmatched_boot_files.append(boot_file_path)
```

**Closes:** \#50, and likely related to \#17 and maybe others.

This is a small, targeted fix so I don't think there should be any breaking changes, but feel free to let me know if something needs to be modified!