### PR TITLE
Fix boot file validation for subvolume-prefixed paths

### DIFF
--- a/src/refind_btrfs/boot/boot_stanza.py
+++ b/src/refind_btrfs/boot/boot_stanza.py
@@ -47,6 +47,7 @@ from refind_btrfs.utility.helpers import (
     is_none_or_whitespace,
     none_throws,
     normalize_dir_separators_in,
+    replace_root_part_in,
     strip_quotes,
 )
 
@@ -190,11 +191,17 @@ class BootStanza:
             boot_file_paths = always_iterable(all_boot_file_paths.get(source))
 
             for boot_file_path in boot_file_paths:
-                # Construct the full, absolute path to the file inside the subvolume
-                full_path_to_check = subvolume.filesystem_path / Path(boot_file_path).relative_to('/')
+                # Handle both paths with subvolume prefix (/@/boot/...) and without (/boot/...)
+                replaced_path_str = replace_root_part_in(
+                    boot_file_path, logical_path, str(subvolume.filesystem_path)
+                )
 
-                # Check if the file actually exists at that location
-                if full_path_to_check.exists():
+                if replaced_path_str == boot_file_path:
+                    replaced_file_path = subvolume.filesystem_path / Path(boot_file_path).relative_to('/')
+                else:
+                    replaced_file_path = Path(replaced_path_str)
+
+                if replaced_file_path.exists():
                     matched_boot_files.append(boot_file_path)
                 else:
                     unmatched_boot_files.append(boot_file_path)


### PR DESCRIPTION
The boot file validation logic introduced in PR #67 broke systems where boot stanzas include the subvolume prefix in file paths (e.g., "/@/boot/vmlinuz-linux-cachyos").

Root cause:
- Some systems specify boot files WITH subvolume prefix: /@/boot/vmlinuz
- Other systems specify boot files WITHOUT prefix: /boot/vmlinuz
- The previous fix only handled the latter case

Solution:
Use a hybrid approach that handles both configurations:
1. Try to replace the subvolume logical path using replace_root_part_in
2. If no replacement occurs (no prefix found), manually construct the path
3. Verify the file actually exists

This ensures compatibility with both valid rEFInd configurations while maintaining the improvement of checking if files actually exist on disk.

Fixes #68